### PR TITLE
change try…except notation for py3k compatibility

### DIFF
--- a/dbg.py
+++ b/dbg.py
@@ -152,19 +152,19 @@ if _user_pref.replace("_local", "").replace("_remote", "") in ('pycharm', 'pydev
                 _active_debugger = 'pydevd_local'
             else:
                 _active_debugger = 'pydevd_remote'
-    except ImportError, pydevd_error:
+    except ImportError as pydevd_error:
         pass
 elif _user_pref == 'winpdb':
     try:
         import rpdb2
         _active_debugger = 'winpdb'
-    except ImportError, rpdb2_error:
+    except ImportError as rpdb2_error:
         pass
 elif _user_pref == 'pdb':
     try:
         import pdb
         _active_debugger = 'pdb'
-    except ImportError, pdb_error:
+    except ImportError as pdb_error:
         pass
 
 if _active_debugger == 'pydevd_remote':


### PR DESCRIPTION
The `try…except E, N` notation isn't supported in Python 3.x. The `try…except E as N` notation works for 2.6 and later (maybe earlier too?).
